### PR TITLE
Add support for nested routes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+const { join } = require('node:path')
 const get = require('lodash.get')
 const toPath = require('lodash.topath')
 
@@ -48,9 +49,10 @@ const getFork = (forks, req) => {
  * Get path with combined search params
  * @param {string} originalUrl - Original URL path
  * @param {string} path - Path to add params to
+ * @param {string} [baseUrl] - Base URL
  * @returns {string} Path with combined search params
  */
-const getPathWithSearchParams = (originalUrl, path) => {
+const getPathWithSearchParams = (originalUrl, path, baseUrl) => {
   if (!path) {
     return ''
   }
@@ -64,6 +66,7 @@ const getPathWithSearchParams = (originalUrl, path) => {
 
   // Remove query string from path
   path = path.split('?')[0]
+  path = baseUrl ? join(baseUrl, path) : path
 
   return pathParams.size ? `${path}?${pathParams.toString()}` : path
 }

--- a/test/wizard-with-base-url.js
+++ b/test/wizard-with-base-url.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict')
+const { describe, it } = require('node:test')
+const wizard = require('../wizard.js')
+
+describe('GOV.UK Prototype Wizard (with baseUrl)', () => {
+  const journey = {
+    '/name': {},
+    '/do-you-have-a-national-insurance-number': {
+      '/email': { data: 'have-nino', value: 'No' }
+    },
+    '/what-is-your-national-insurance-number': {},
+    '/email': {}
+  }
+
+  it('Returns current, next and previous paths', () => {
+    const req = {
+      baseUrl: '/questions',
+      method: 'POST',
+      originalUrl: '/questions/do-you-have-a-national-insurance-number',
+      path: '/do-you-have-a-national-insurance-number',
+      session: { data: { 'have-nino': 'No' } }
+    }
+
+    assert.deepEqual(wizard(journey, req), {
+      back: '/questions/name',
+      current: '/questions/do-you-have-a-national-insurance-number',
+      next: '/questions/email'
+    })
+  })
+
+  it('Returns next path with modified query string', () => {
+    const journey = {
+      '/filter/location': {},
+      '/list?success=1': {}
+    }
+
+    const req = {
+      baseUrl: '/results',
+      method: 'POST',
+      originalUrl: '/results/filter/location?page=2&sort=asc',
+      path: '/filter/location',
+      query: {
+        page: '2',
+        sort: 'asc'
+      },
+      session: { data: {} }
+    }
+
+    assert.deepEqual(wizard(journey, req), {
+      back: '',
+      current: '/results/filter/location?page=2&sort=asc',
+      next: '/results/list?success=1&page=2&sort=asc'
+    })
+  })
+
+  it('Adds fork data pointing back to where user forked from', () => {
+    const req = {
+      baseUrl: '/questions',
+      method: 'GET',
+      originalUrl: '/questions/email',
+      path: '/email',
+      session: {
+        data: {
+          'forked-to': '/email',
+          'forked-from': '/do-you-have-a-national-insurance-number'
+        }
+      }
+    }
+
+    assert.deepEqual(wizard(journey, req), {
+      back: '/questions/do-you-have-a-national-insurance-number',
+      current: '/questions/email',
+      next: ''
+    })
+  })
+
+  it('Removes fork data when returning to page that created it', () => {
+    const req = {
+      baseUrl: '/questions',
+      method: 'GET',
+      session: {
+        data: {
+          'forked-from': '/do-you-have-a-national-insurance-number',
+          'forked-to': '/email'
+        }
+      },
+      originalUrl: '/questions/do-you-have-a-national-insurance-number',
+      path: '/do-you-have-a-national-insurance-number'
+    }
+
+    wizard(journey, req)
+
+    assert.equal(req.session.data['forked-from'], undefined)
+    assert.equal(req.session.data['forked-to'], undefined)
+  })
+})

--- a/wizard.js
+++ b/wizard.js
@@ -2,13 +2,12 @@ const utils = require('./lib/utils.js')
 
 /**
  * Get next, back and current paths in user journey.
- *
- * @param {Object} journey - Sequence of paths in user journey
- * @param {Object} req - Express request
- * @returns {Object} Next and back paths
+ * @param {object} journey - Sequence of paths in user journey
+ * @param {object} req - Express request
+ * @returns {object} Next and back paths
  */
 const wizard = (journey, req) => {
-  const { method, originalUrl, path, session } = req
+  const { baseUrl, method, originalUrl, path, session } = req
   const { data } = session
   const paths = Object.keys(journey)
   const index = paths.indexOf(path)
@@ -40,8 +39,8 @@ const wizard = (journey, req) => {
   }
 
   return {
-    next: utils.getPathWithSearchParams(originalUrl, next),
-    back: utils.getPathWithSearchParams(originalUrl, back),
+    next: utils.getPathWithSearchParams(originalUrl, next, baseUrl),
+    back: utils.getPathWithSearchParams(originalUrl, back, baseUrl),
     current: originalUrl
   }
 }


### PR DESCRIPTION
With `express.Router`, it’s possible to create self-contained routing beneath a path set in a parent router. Using an example [slightly modified from the Express JS documentation](https://expressjs.com/en/guide/routing.html#express-router):

```js
// birds.js
import express from 'express'

const router = express.Router()

router.get('/', (req, res) => {
  res.send('Birds home page')
})

router.get('/about', (req, res) => {
  res.send('About birds')
})

export const birdRoutes = router
```

```js
// routes.js
import { birdRoutes } from 'birds.js'

app.use('/birds', birdRoutes)
```

The app will now be able to handle requests to `/birds` and `/birds/about`.

However, while this library looks for paths that match `req.originalUrl`, it only creates next and previous paths based on the route handler. For example, given the following journey:

```js
const journey = {
  '/': {},
  '/about': {}
  '/species': {}
}
```

Upon visiting `/about`, the following `paths` object is provided:

```
{
  back: '/',
  current: '/birds/about',
  next: '/species'
}
```

Note that `back` and `next` values don’t contain the parent path segment. Clicking on links containing those values will return the wrong (or no) page.

***

This PR appends `req.baseUrl` which includes this information. With this fix in place, the following paths are generated:

```
{
  back: '/birds',
  current: '/birds/about',
  next: '/birds/species'
}
```

If there is no `req.baseUrl`, the previous behaviour is retained.